### PR TITLE
fix email sending issue

### DIFF
--- a/src/api/server/services/orders/orders.js
+++ b/src/api/server/services/orders/orders.js
@@ -661,11 +661,15 @@ class OrdersService {
 				subject: subject,
 				html: body
 			}),
-			mailer.send({
-				to: copyTo,
-				subject: subject,
-				html: body
-			})
+			() => {
+				if ((copyTo != null || copyTo != undefined) && copyTo.length > 0) {
+					mailer.send({
+						to: copyTo,
+						subject: subject,
+						html: body
+					});
+				}
+			}
 		]);
 	}
 


### PR DESCRIPTION
When complete check out a product, emails will be sent out, this will cause issue if  "copyTo" email is null or empty.