### PR TITLE
Initial data setup added

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,4 +4,5 @@ set -e
 envsubst '${API_PORT}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
 nginx
+exec npm run setup admin@example.com http://localhost:3000
 exec pm2 start process.json --no-daemon


### PR DESCRIPTION
Initial cezerin data setup added to the docker-entrypoint.sh

By default, with docker installation of cezerin we don't have default data and settings.

Fix.