### PR TITLE
Product Image 504 error on upload

### DIFF
--- a/src/services/assets/local.js
+++ b/src/services/assets/local.js
@@ -104,8 +104,7 @@ class LocalService {
 
 	uploadFiles(req, res, dir, onFileUpload, onFilesEnd) {
 		const uploadedFiles = [];
-
-		fse.ensureDirSync(path);
+		fse.ensureDirSync(dir);
 
 		const form = new formidable.IncomingForm();
 		form.uploadDir = path.resolve(dir);
@@ -114,7 +113,7 @@ class LocalService {
 			.on('fileBegin', (name, file) => {
 				// Emitted whenever a field / value pair has been received.
 				file.name = utils.getCorrectFileName(file.name);
-				file.path = `${path}/${file.name}`;
+				file.path = `${dir}/${file.name}`;
 			})
 			.on('file', async (field, file) => {
 				// every time a file has been uploaded successfully,


### PR DESCRIPTION
When cezerin2 using default asset settings, product Images fail to upload. You receive uploading until the file upload times out.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to 'cezerin2-admin'
2. Go to any product
3. Scroll down to bottom
4. upload image
5. go to api logs for details

**Expected behavior**
Image should upload

**Screenshots**
![image](https://user-images.githubusercontent.com/6520289/58244563-2ae92680-7d96-11e9-83c0-59cb3462be2d.png)

