### PR TITLE
catch empty payment method update

### DIFF
--- a/src/services/orders/paymentMethods.ts
+++ b/src/services/orders/paymentMethods.ts
@@ -198,10 +198,6 @@ class PaymentMethodsService {
   }
 
   getValidDocumentForUpdate(id, data) {
-    if (Object.keys(data).length === 0) {
-      return new Error("Required fields are missing")
-    }
-
     const method = {}
 
     if (data.name !== undefined) {
@@ -226,6 +222,10 @@ class PaymentMethodsService {
 
     if (data.gateway !== undefined) {
       method.gateway = parse.getString(data.gateway)
+    }
+    
+    if (Object.keys(method).length === 0) {
+      return new Error("Required fields are missing")
     }
 
     return method


### PR DESCRIPTION
if an object is passed in with invalid keys an empty object will be sent to db causing a mongo error.