### PR TITLE
Fix Improper Access Control

### DIFF
--- a/src/services/orders/orders.ts
+++ b/src/services/orders/orders.ts
@@ -252,7 +252,26 @@ class OrdersService {
       return Promise.reject("Invalid identifier")
     }
     const orderObjectID = new ObjectID(id)
-    const orderData = await this.getValidDocumentForUpdate(id, data)
+    // Accept certain data
+    let dataValidation = Object.assign({},
+        data,
+        {paid: undefined},
+        {payment_token: undefined},
+        {shipping_tax: undefined},
+        {shipping_discount: undefined},
+        {shipping_price: undefined},
+        {tax_rate: undefined},
+        {item_tax_included: undefined},
+        {shipping_tax_included: undefined},
+        {closed: undefined},
+        {cancelled: undefined},
+        {delivered: undefined},
+        {hold: undefined},
+        {tracking_number: undefined},
+        {shipping_status: undefined},
+        {date_paid: undefined}
+    );
+    const orderData = await this.getValidDocumentForUpdate(id, dataValidation);
     const updateResponse = await db
       .collection("orders")
       .updateOne({ _id: orderObjectID }, { $set: orderData })


### PR DESCRIPTION
### ⚙️ Description *

The vulnerability exists in the checkout page which allows an attacker to send extra parameter values e.g `paid`, which result in manipulating the order status to paid (without paying anything)

### 💻 Technical Description *

The vulnerabilities leads to _src/ajaxRouter.ts_ .  The route is responsible for checking the order id in the cookie. If there is order id then it calls api.orders.checkout in cezerin-client module

```javascript
ajaxRouter.put('/cart/checkout', (req, res, next) => {
	const order_id = req.signedCookies.order_id;
	if (order_id) {
		api.orders
			.checkout(order_id)
			.then(cartResponse => fillCartItems(cartResponse))
			.then(({ status, json }) => {
				res.clearCookie('order_id');
				res.status(status).send(json);
			});
	} else {
		res.end();
	}
});
```

The cezerin-client sends the request to the order API route.

File: _node_modules/cezerin-client/lib/api/orders/orders.js_
```javascript
key: 'checkout',
value: function checkout(orderId) {
	return this.client.put(this.resourceUrl + '/' + orderId + '/checkout');
}
```

and if we look into the order api file we can see that it call checkoutOrder function
File: _src/routes/orders.ts_
```javascript
this.router.put(
	'/v1/orders/:id/checkout',
	security.checkUserScope.bind(this, security.scope.WRITE_ORDERS),
	this.checkoutOrder.bind(this)
);
```

The checkout function calls the updateOrder function. The update function send the Object (_data_) to getValidDocumentForUpdate, this function is for generating orders and it does have certain attributes that if provided can result in order manipulation e.g `paid` `shipping_discount` `shipping_price` `tax_rate` etc..

File: _src/services/orders/orders.ts_
```javascript
async checkoutOrder(orderId) {
	const [order, emailTemplate, dashboardSettings] = await Promise.all([
		this.getOrCreateCustomer(orderId).then(customer_id => {
			return this.updateOrder(orderId, {
				customer_id: customer_id,
				date_placed: new Date(),
				draft: false});
}),	
..
..
..
async updateOrder(id, data) {
	if (!ObjectID.isValid(id)) {
		return Promise.reject('Invalid identifier');
	}
		const orderObjectID = new ObjectID(id);
		const orderData = await this.getValidDocumentForUpdate(id, data);
```

The solution I come up is to only send the data to the function that is required from the user any extra value if being sent will be overridden with undefined value and there is already a check for an undefined value in getValidDocumentForUpdate function which does check it through the server-side

```javascript
// Accept certain data
let dataValidation = Object.assign({},
	data,
	{paid: undefined},
	{payment_token: undefined},
	{shipping_tax: undefined},
	{shipping_discount: undefined},
	{shipping_price: undefined},
	{tax_rate: undefined},
	{item_tax_included: undefined},
	{shipping_tax_included: undefined},
	{closed: undefined},
	{cancelled: undefined},
	{delivered: undefined},
	{hold: undefined},
	{tracking_number: undefined},
	{shipping_status: undefined},
	{date_paid: undefined}
	);
	const orderData = await this.getValidDocumentForUpdate(id, dataValidation);
```



### 🐛 Proof of Concept (PoC) *

1. Add any item to the chart and checkout.

![01_Add_Item](https://user-images.githubusercontent.com/17072444/82118340-61a11500-973c-11ea-9426-70cbddeeeeb7.PNG)

2. Add additional attributes (e.g., paid, tax_rate, shipping_price, shipping_discount, etc.) to the user input field in the request. In my case I added `paid`
```code
PUT /ajax/cart HTTP/1.1
Host: localhost:3001
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:76.0) Gecko/20100101 Firefox/76.0
Accept: */*
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
Content-Type: application/json
Content-Length: 752
Origin: http://localhost:3000
Referer: http://localhost:3000/checkout
Connection: close
Cookie: referrer_url=s%3Ahttp%3A%2F%2Flocalhost%3A3002%2Fproduct%2F5ebf904f019a46570832cb1f.YDyXRnpoWg0Cn6i%2BL2kx2UETY0PqY8%2BXWJ5LPCyoJ%2Fo; landing_url=s%3Ahttp%3A%2F%2Flocalhost%2F.tyZ3uwyR9gAuGEJzxP6kxtZ8cXlAsZTbPH6NKLaAhHk; order_id=s%3A5ebfc8fe30e7a22e0884afdf.bmuz92dPI6fLGaNVOxXckNXktUZDtsBNFR1z2pb4NXA

{"shipping_address":{"address1":"Testbug street","address2":"Testbug street","city":"testbug","country":"US","state":"TESTBUG","phone":"","postal_code":"00001","full_name":"","company":"","tax_number":"","coordinates":{"latitude":"","longitude":""},"details":null},"billing_address":{"address1":"","address2":"","city":"","country":"","state":"","phone":"","postal_code":"","full_name":"","company":"","tax_number":"","coordinates":{"latitude":"","longitude":""},"details":null},"email":"testbug@testbug.com","mobile":"+11312312312","first_name":"Testbug","last_name":"Testbug","password":"http://localhost:3000/checkout","payment_method_id":"5ebf904f019a46570832cb29","shipping_method_id":"5ebf904f019a46570832cb28","comments":"", "paid": true}
```


![02_Modify_Request](https://user-images.githubusercontent.com/17072444/82118517-88138000-973d-11ea-8ce8-863b49ab230d.PNG)


3. The status of the order is set as paid without payments. 

![03_Paid](https://user-images.githubusercontent.com/17072444/82118491-6a461b00-973d-11ea-92e2-bf53dcd5cb66.PNG)

![04_Paid](https://user-images.githubusercontent.com/17072444/82118495-6ca87500-973d-11ea-8075-656742fb7fbd.PNG)


### 🔥 Proof of Fix (PoF) *

1. Add any item to the chart and checkout.
2. Add additional attributes (e.g., paid, tax_rate, shipping_price, shipping_discount, etc.) to the user input field in the request. In my case I added `paid`

![02_Modify_Request](https://user-images.githubusercontent.com/17072444/82118548-c01ac300-973d-11ea-93e7-ec5ca9f604e9.PNG)

3. The status of the order is not set as paid without payments. 

![04_Status](https://user-images.githubusercontent.com/17072444/82118574-d9bc0a80-973d-11ea-9946-22e55ccc0bcb.PNG)



### 👍 User Acceptance Testing (UAT)

- Add `tax_rate` , `shipping_price`, `paid` , `payment_token` etc.. in the request.


Fix #269 